### PR TITLE
add missing center to grid coordinates

### DIFF
--- a/src/torch_rotate_image/rotate_image_2d.py
+++ b/src/torch_rotate_image/rotate_image_2d.py
@@ -21,18 +21,18 @@ def rotate_image_2d(image: torch.Tensor, angles: float | torch.Tensor) -> torch.
     """
 
     h, w = image.shape[-2:]
-    grid = coordinate_grid(
-        image_shape=(h, w), center=(h // 2, w // 2), device=image.device
-    )  # (h, w, 2)
+    center = (h // 2, w // 2)
+    grid = coordinate_grid(image_shape=(h, w), center=center, device=image.device)
     # TODO make angles a Tensor
     rotation_matrices = _rotation_matrix_from_angles(angles)  # (..., 2, 2)
     # Prepare for broadcasting
     grid = einops.rearrange(grid, "h w yx -> h w yx 1")
     rotation_matrices = einops.rearrange(rotation_matrices, "... i j -> ... 1 1 i j")
     # (..., h, w, 2, 1) target shape for rotated output grid
-    rot_grid = rotation_matrices @ grid  # (..., h, w, 2, 1)
-    rot_grid = einops.rearrange(rot_grid, "... h w yx 1 -> ... h w yx")
-    rotated_images = sample_image_2d(image=image, coordinates=rot_grid)  # (..., h, w)
+    rotated_coords = rotation_matrices @ grid  # (..., h, w, 2, 1)
+    rotated_coords = einops.rearrange(rotated_coords, "... h w yx 1 -> ... h w yx")
+    rotated_coords += center
+    rotated_images = sample_image_2d(image=image, coordinates=rotated_coords)  # (..., h, w)
     return rotated_images
 
 

--- a/tests/test_torch_rotate_image.py
+++ b/tests/test_torch_rotate_image.py
@@ -12,6 +12,6 @@ def test_rotate_image_2d_shape():
 def test_rotate_image_2d_rotation():
     image = torch.zeros(28, 28)
     image[:14, :] = 1  # image is half black, half white
-    angles = torch.tensor([0.0, 180.0])
+    angles = torch.tensor([180.0, ])
     rotated_image = rotate_image_2d(image, angles)
     assert (rotated_image[0] == image) and (rotated_image[1] == image.flip(0))


### PR DESCRIPTION
closes #4 

@sjrothfuss we had centered coordinates and rotated them but we need to un-center them for sampling. This is needed because the sampling utilities in torch image lerp expect coordinates which align with array indices `[0, n-1]` for each dim

hope this helps!